### PR TITLE
correct txn db lock logic, issue #34 fsync on commit, add Update method for txns similar to boltdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Starskey is a fast embedded key-value store package for GO!  Starskey implements
 
 ## Features
 - **Levelled partial merge compaction**  Compactions occur on writes, if any disk level reaches it's max size half of the sstables are merged into a new sstable and placed into the next level.  This algorithm is recursive until last level.  At last level if full we merge all sstables into a new sstable.
-- **Simple API** with Put, Get, Delete, Range, FilterKeys
+- **Simple API** with Put, Get, Delete, Range, FilterKeys, Update (for txns)
 - **Atomic transactions** You can group multiple operations into a single atomic transaction.  If any operation fails the entire transaction is rolled back.  Only committed transactions roll back.
 - **Configurable options** You can configure many options such as max levels, memtable threshold, bloom filter, and more.
 - **WAL with recovery** Starskey uses a write ahead log to ensure durability.  Memtable is replayed if a flush did not occur prior to shutdown.  On sorted runs to disk the WAL is truncated.
@@ -105,6 +105,19 @@ txn.Put([]byte("key"), []byte("value"))
 
 if err := txn.Commit(); err != nil {
     t.Fatalf("Failed to commit transaction: %v", err)
+}
+```
+
+OR
+
+```go
+err = starskey.Update(func(txn *Txn) error {
+    txn.Put([]byte("key"), []byte("value")) // or txn.Delete, txn.Get
+    // ..
+    return nil
+})
+if err != nil {
+    t.Fatalf("Failed to update: %v", err)
 }
 ```
 

--- a/pager/pager.go
+++ b/pager/pager.go
@@ -357,3 +357,8 @@ func (it *Iterator) stackAdd(pg int) {
 func (p *Pager) FileName() string {
 	return p.file.Name()
 }
+
+// EscalateFSync escalates an fsync to disk sending a trigger through channel
+func (p *Pager) EscalateFSync() {
+	p.file.Sync()
+}

--- a/starskey_test.go
+++ b/starskey_test.go
@@ -307,6 +307,51 @@ func TestStarskey_BeginTxn(t *testing.T) {
 
 }
 
+func TestStarskey_Update(t *testing.T) {
+	_ = os.RemoveAll("test")
+	defer func() {
+		_ = os.RemoveAll("test")
+	}()
+
+	// Define a valid configuration
+	config := &Config{
+		Permission:     0755,
+		Directory:      "test",
+		FlushThreshold: 13780 / 2,
+		MaxLevel:       3,
+		SizeFactor:     10,
+		BloomFilter:    false,
+		Logging:        false,
+	}
+
+	starskey, err := Open(config)
+	if err != nil {
+		t.Fatalf("Failed to open starskey: %v", err)
+	}
+
+	err = starskey.Update(func(txn *Txn) error {
+		txn.Put([]byte("key"), []byte("value"))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Failed to update: %v", err)
+	}
+
+	// Get
+	val, err := starskey.Get([]byte("key"))
+	if err != nil {
+		t.Fatalf("Failed to get key-value pair: %v", err)
+	}
+
+	if !reflect.DeepEqual(val, []byte("value")) {
+		t.Fatalf("Value does not match expected value")
+	}
+
+	if err := starskey.Close(); err != nil {
+		t.Fatalf("Failed to close starskey: %v", err)
+	}
+}
+
 func TestStarskey_Reopen(t *testing.T) {
 	_ = os.RemoveAll("test")
 	defer func() {


### PR DESCRIPTION
- correct txn db lock logic
- issue #34 fsync on commit
- add Update method for txns similar to boltdb #33
- add Get for txns #33
