### PR TITLE
- made is so on deletes bloom filter recreates itself.. more

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/starskey-io/starskey
 go 1.23
 
 require (
+	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/klauspost/compress v1.16.7
 	github.com/zeebo/xxh3 v1.0.2
 	go.mongodb.org/mongo-driver v1.17.2

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=

--- a/surf/surf.go
+++ b/surf/surf.go
@@ -1,0 +1,561 @@
+// Package ttree
+//
+// (C) Copyright Starskey
+//
+// Original Author: Alex Gaetano Padula
+//
+// Licensed under the Mozilla Public License, v. 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.mozilla.org/en-US/MPL/2.0/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package surf
+
+import (
+	"bytes"
+	"encoding/gob"
+	"math"
+
+	"github.com/cespare/xxhash/v2"
+)
+
+// SuRF represents a succinct filter inspired by https://www.cs.cmu.edu/~huanche1/publications/surf_paper.pdf
+type SuRF struct {
+	Trie       *TrieNode // Root node of the trie
+	SuffixBits int       // Number of suffix bits for better filtering
+	HashBits   int       // Number of hash bits for better filtering
+	TotalKeys  uint64    // Track total keys for adaptive suffix sizing
+}
+
+// TrieNode represents a node in the SuRF trie
+type TrieNode struct {
+	Children map[byte]*TrieNode // Map of children nodes
+	IsLeaf   bool               // Indicates if the node is a leaf
+	Suffix   uint64             // Suffix bits for better filtering
+	Hash     uint64             // Additional hash for better filtering
+	Height   int                // Track node height for balanced deletion
+}
+
+// NewSuRF initializes a new SuRF
+func NewSuRF(expectedKeys int) *SuRF {
+	return &SuRF{
+		Trie:       &TrieNode{Children: make(map[byte]*TrieNode), Height: 1},
+		SuffixBits: OptimalSuffixBits(expectedKeys),
+		HashBits:   OptimalHashBits(expectedKeys),
+		TotalKeys:  0,
+	}
+}
+
+// OptimalSuffixBits calculates the optimal number of suffix bits for better filtering
+func OptimalSuffixBits(totalKeys int) int {
+	entropy := math.Log2(float64(totalKeys))
+	baseBits := int(math.Ceil(entropy / 4))
+	if baseBits < 4 {
+		return 4
+	}
+	if baseBits > 16 {
+		return 16
+	}
+	return baseBits
+}
+
+// OptimalHashBits calculates the optimal number of hash bits for better filtering
+func OptimalHashBits(totalKeys int) int {
+	return OptimalSuffixBits(totalKeys) * 2
+}
+
+// Add inserts a key into the SuRF
+func (s *SuRF) Add(key []byte) {
+	node := s.Trie
+	path := make([]byte, 0, len(key))
+
+	for _, b := range key {
+		path = append(path, b)
+		if _, exists := node.Children[b]; !exists {
+			node.Children[b] = &TrieNode{
+				Children: make(map[byte]*TrieNode),
+				Height:   len(path),
+			}
+		}
+		node = node.Children[b]
+	}
+
+	node.IsLeaf = true
+	node.Suffix = mixedSuffixBits(key, s.SuffixBits)
+	node.Hash = computeNodeHash(key, path, s.HashBits)
+	s.TotalKeys++
+
+	// Rebalance if needed
+	s.rebalanceAfterAdd(node)
+}
+
+// CheckRange checks if a range of keys exists in the SuRF
+func (s *SuRF) CheckRange(lower, upper []byte) bool {
+	return s.checkRangeHelper(s.Trie, lower, upper, 0, make([]byte, 0))
+}
+
+// checkRangeHelper recursively checks if a range of keys exists in the SuRF
+func (s *SuRF) checkRangeHelper(node *TrieNode, lower, upper []byte, depth int, path []byte) bool {
+	if node == nil {
+		return false
+	}
+
+	if node.IsLeaf {
+		suffix := mixedSuffixBits(lower, s.SuffixBits)
+		upperSuffix := mixedSuffixBits(upper, s.SuffixBits)
+
+		// Enhanced filtering using both suffix and hash
+		if node.Suffix >= suffix && node.Suffix <= upperSuffix {
+			nodeHash := computeNodeHash(path, path, s.HashBits)
+			if node.Hash == nodeHash {
+				return true
+			}
+		}
+		return false
+	}
+
+	for b, child := range node.Children {
+		newPath := append(path, b)
+		if depth < len(lower) && depth < len(upper) {
+			if b >= lower[depth] && b <= upper[depth] {
+				if s.checkRangeHelper(child, lower, upper, depth+1, newPath) {
+					return true
+				}
+			}
+		} else if depth >= len(lower) && depth < len(upper) {
+			if b <= upper[depth] {
+				if s.checkRangeHelper(child, lower, upper, depth+1, newPath) {
+					return true
+				}
+			}
+		} else if depth < len(lower) && depth >= len(upper) {
+			if b >= lower[depth] {
+				if s.checkRangeHelper(child, lower, upper, depth+1, newPath) {
+					return true
+				}
+			}
+		} else {
+			if s.checkRangeHelper(child, lower, upper, depth+1, newPath) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// mixedSuffixBits computes a combined suffix using both hash and real suffix
+func mixedSuffixBits(key []byte, bits int) uint64 {
+	if len(key) == 0 {
+		return 0
+	}
+
+	hashValue := xxhash.Sum64(key)
+	var realSuffix uint64
+
+	suffixStart := max(0, len(key)-bits/4)
+	for i := suffixStart; i < len(key); i++ {
+		realSuffix = (realSuffix << 8) | uint64(key[i])
+	}
+
+	mask := uint64((1 << bits) - 1)
+	return ((hashValue & (mask >> 1)) << (bits / 2)) | (realSuffix & ((1 << (bits / 2)) - 1))
+}
+
+// computeNodeHash computes a hash for a node using both key and path
+func computeNodeHash(key []byte, path []byte, bits int) uint64 {
+	combined := append(path, key...)
+	hash := xxhash.Sum64(combined)
+	return hash & ((1 << bits) - 1)
+}
+
+// Delete removes a key from the SuRF
+func (s *SuRF) Delete(key []byte) bool {
+	success, _ := s.deleteHelper(s.Trie, key, 0, nil)
+	if success {
+		s.TotalKeys--
+	}
+	return success
+}
+
+// deleteHelper returns two booleans: the first indicates if the key was successfully deleted,
+func (s *SuRF) deleteHelper(node *TrieNode, key []byte, depth int, parent *TrieNode) (bool, bool) {
+	if node == nil {
+		return false, false
+	}
+
+	if depth == len(key) {
+		if !node.IsLeaf {
+			return false, false
+		}
+
+		node.IsLeaf = false
+		shouldDelete := len(node.Children) == 0
+
+		// Update heights
+		if parent != nil && shouldDelete {
+			s.updateHeights(parent)
+		}
+
+		return true, shouldDelete
+	}
+
+	b := key[depth]
+	child, exists := node.Children[b]
+	if !exists {
+		return false, false
+	}
+
+	deleted, shouldDelete := s.deleteHelper(child, key, depth+1, node)
+	if shouldDelete {
+		delete(node.Children, b)
+
+		// Clean up empty non-leaf node
+		if !node.IsLeaf && len(node.Children) == 0 {
+			return deleted, true
+		}
+
+		// Rebalance if needed
+		s.rebalanceAfterDelete(node)
+	}
+
+	return deleted, false
+}
+
+// rebalanceAfterAdd rebalances the tree after an addition
+func (s *SuRF) rebalanceAfterAdd(node *TrieNode) {
+	if node == nil {
+		return
+	}
+
+	maxHeight := 0
+	minHeight := math.MaxInt32
+
+	for _, child := range node.Children {
+		if child.Height > maxHeight {
+			maxHeight = child.Height
+		}
+		if child.Height < minHeight {
+			minHeight = child.Height
+		}
+	}
+
+	// Update node height
+	node.Height = maxHeight + 1
+
+	// Check if rebalancing is needed
+	if maxHeight-minHeight > 1 {
+		s.rotateNode(node)
+	}
+}
+
+// rebalanceAfterDelete rebalances the tree after a deletion
+func (s *SuRF) rebalanceAfterDelete(node *TrieNode) {
+	if node == nil {
+		return
+	}
+
+	s.updateHeights(node)
+
+	// Check balance factor
+	balance := s.getBalance(node)
+	if math.Abs(float64(balance)) > 1 {
+		s.rotateNode(node)
+	}
+}
+
+// updateHeights updates the height of a node based on its children
+func (s *SuRF) updateHeights(node *TrieNode) {
+	if node == nil {
+		return
+	}
+
+	maxHeight := 0
+	for _, child := range node.Children {
+		if child.Height > maxHeight {
+			maxHeight = child.Height
+		}
+	}
+
+	node.Height = maxHeight + 1
+}
+
+// getBalance returns the balance factor of a node
+func (s *SuRF) getBalance(node *TrieNode) int {
+	if node == nil {
+		return 0
+	}
+
+	leftHeight := 0
+	rightHeight := 0
+
+	// Find leftmost and rightmost children
+	for _, child := range node.Children {
+		if child.Height > leftHeight {
+			leftHeight = child.Height
+		}
+		if child.Height > rightHeight {
+			rightHeight = child.Height
+		}
+	}
+
+	return leftHeight - rightHeight
+}
+
+// rotateNode performs the necessary rotations to balance the node
+func (s *SuRF) rotateNode(node *TrieNode) {
+	balance := s.getBalance(node)
+
+	// Get the highest and lowest byte keys
+	var highestByte, lowestByte byte
+	first := true
+	for b := range node.Children {
+		if first {
+			highestByte = b
+			lowestByte = b
+			first = false
+			continue
+		}
+		if b > highestByte {
+			highestByte = b
+		}
+		if b < lowestByte {
+			lowestByte = b
+		}
+	}
+
+	if balance > 1 { // Left-heavy
+		leftChild := node.Children[lowestByte]
+
+		// Determine rotation type
+		leftBalance := s.getBalance(leftChild)
+		if leftBalance < 0 {
+			// Left-Right rotation needed
+			s.rotateLeft(leftChild)
+		}
+		s.rotateRight(node)
+
+	} else if balance < -1 { // Right-heavy
+		rightChild := node.Children[highestByte]
+
+		// Determine rotation type
+		rightBalance := s.getBalance(rightChild)
+		if rightBalance > 0 {
+			// Right-Left rotation needed
+			s.rotateRight(rightChild)
+		}
+		s.rotateLeft(node)
+	}
+}
+
+// rotateLeft rotates the node to the left
+func (s *SuRF) rotateLeft(node *TrieNode) {
+	// Find the rightmost child
+	var rightmostByte byte
+	var rightChild *TrieNode
+	for b, child := range node.Children {
+		if rightChild == nil || b > rightmostByte {
+			rightmostByte = b
+			rightChild = child
+		}
+	}
+
+	if rightChild == nil {
+		return // Cannot rotate if no right child
+	}
+
+	// Store original node's children except rightmost
+	oldChildren := make(map[byte]*TrieNode)
+	for b, child := range node.Children {
+		if b != rightmostByte {
+			oldChildren[b] = child
+		}
+	}
+
+	// Move appropriate children from right child to node
+	var lowestByteInRight byte
+	first := true
+	for b, _ := range rightChild.Children {
+		if first {
+			lowestByteInRight = b
+			first = false
+		}
+		if b < lowestByteInRight {
+			lowestByteInRight = b
+		}
+	}
+
+	// Redistribute children
+	newNodeChildren := make(map[byte]*TrieNode)
+	for b, child := range rightChild.Children {
+		if b < lowestByteInRight {
+			newNodeChildren[b] = child
+			delete(rightChild.Children, b)
+		}
+	}
+
+	// Update the children maps
+	for b, child := range oldChildren {
+		newNodeChildren[b] = child
+	}
+	node.Children = newNodeChildren
+
+	// Update heights
+	s.updateHeights(node)
+	s.updateHeights(rightChild)
+}
+
+// rotateRight rotates the node to the right
+func (s *SuRF) rotateRight(node *TrieNode) {
+	// Find the leftmost child
+	var leftmostByte byte
+	var leftChild *TrieNode
+	first := true
+	for b, child := range node.Children {
+		if first || b < leftmostByte {
+			leftmostByte = b
+			leftChild = child
+			first = false
+		}
+	}
+
+	if leftChild == nil {
+		return // Cannot rotate if no left child
+	}
+
+	// Store original node's children except leftmost
+	oldChildren := make(map[byte]*TrieNode)
+	for b, child := range node.Children {
+		if b != leftmostByte {
+			oldChildren[b] = child
+		}
+	}
+
+	// Move appropriate children from left child to node
+	var highestByteInLeft byte
+	first = true
+	for b, _ := range leftChild.Children {
+		if first {
+			highestByteInLeft = b
+			first = false
+			continue
+		}
+		if b > highestByteInLeft {
+			highestByteInLeft = b
+		}
+	}
+
+	// Redistribute children
+	newNodeChildren := make(map[byte]*TrieNode)
+	for b, child := range leftChild.Children {
+		if b > highestByteInLeft {
+			newNodeChildren[b] = child
+			delete(leftChild.Children, b)
+		}
+	}
+
+	// Update the children maps
+	for b, child := range oldChildren {
+		newNodeChildren[b] = child
+	}
+	node.Children = newNodeChildren
+
+	// Handle leaf status and suffix/hash transfer if needed
+	if node.IsLeaf {
+		leftChild.IsLeaf = true
+		leftChild.Suffix = node.Suffix
+		leftChild.Hash = node.Hash
+		node.IsLeaf = false
+	}
+
+	// Update heights
+	s.updateHeights(node)
+	s.updateHeights(leftChild)
+}
+
+// Helper function to get the leftmost and rightmost bytes of a node's children
+func (s *SuRF) getExtremeBytes(node *TrieNode) (byte, byte) {
+	var lowest, highest byte
+	first := true
+
+	for b := range node.Children {
+		if first {
+			lowest = b
+			highest = b
+			first = false
+			continue
+		}
+		if b < lowest {
+			lowest = b
+		}
+		if b > highest {
+			highest = b
+		}
+	}
+
+	return lowest, highest
+}
+
+// Helper function to get the height of a child node
+func (s *SuRF) getChildHeight(node *TrieNode, b byte) int {
+	if child, exists := node.Children[b]; exists {
+		return child.Height
+	}
+	return 0
+}
+
+// Serialize converts the SuRF to a byte slice
+func (s *SuRF) Serialize() ([]byte, error) {
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+	if err := enc.Encode(s); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// Deserialize reconstructs a SuRF from a byte slice
+func Deserialize(data []byte) (*SuRF, error) {
+	var s SuRF
+	buf := bytes.NewReader(data)
+	dec := gob.NewDecoder(buf)
+	if err := dec.Decode(&s); err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+// Contains checks if a key exists in the SuRF
+func (s *SuRF) Contains(key []byte) bool {
+	node := s.Trie
+	path := make([]byte, 0, len(key))
+
+	// Traverse the trie following the key path
+	for _, b := range key {
+		path = append(path, b)
+		child, exists := node.Children[b]
+		if !exists {
+			return false
+		}
+		node = child
+	}
+
+	// We've reached the end of the key path
+	if !node.IsLeaf {
+		return false
+	}
+
+	// Verify both suffix and hash match for better filtering
+	expectedSuffix := mixedSuffixBits(key, s.SuffixBits)
+	if node.Suffix != expectedSuffix {
+		return false
+	}
+
+	expectedHash := computeNodeHash(key, path, s.HashBits)
+	return node.Hash == expectedHash
+}

--- a/surf/surf_test.go
+++ b/surf/surf_test.go
@@ -1,0 +1,369 @@
+// Package ttree
+//
+// (C) Copyright Starskey
+//
+// Original Author: Alex Gaetano Padula
+//
+// Licensed under the Mozilla Public License, v. 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.mozilla.org/en-US/MPL/2.0/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package surf
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+// TestSuRF tests the SuRF implementation with 1 million random keys and range checks
+func TestSuRF(t *testing.T) {
+	rand.Seed(time.Now().UnixNano())
+	surf := NewSuRF(8)
+	keys := make([][]byte, 1000000)
+
+	// Insert 1 million random keys
+	for i := 0; i < 1000000; i++ {
+		key := []byte(fmt.Sprintf("%08d", rand.Intn(99999999)))
+		keys[i] = key
+		surf.Add(key)
+	}
+
+	// Perform range checks
+	checks := []struct {
+		lower, upper []byte
+	}{
+		{[]byte("00001000"), []byte("00002000")},
+		{[]byte("50000000"), []byte("60000000")},
+		{[]byte("90000000"), []byte("99999999")},
+		{[]byte("12345678"), []byte("23456789")},
+		{[]byte("70000000"), []byte("80000000")},
+	}
+
+	for _, check := range checks {
+		exists := surf.CheckRange(check.lower, check.upper)
+		t.Logf("CheckRange(%s, %s) = %v", check.lower, check.upper, exists)
+	}
+}
+
+// Generates a sequentially increasing set of keys
+func generateSequentialKeys(n int) [][]byte {
+	keys := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		keys[i] = []byte(fmt.Sprintf("%08d", i))
+	}
+	return keys
+}
+
+// Generates keys with Zipfian distribution
+func generateZipfianKeys(n int) [][]byte {
+	rand.Seed(time.Now().UnixNano())
+	zipf := rand.NewZipf(rand.New(rand.NewSource(time.Now().UnixNano())), 1.1, 2, uint64(n-1))
+	keys := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		keys[i] = []byte(fmt.Sprintf("%08d", zipf.Uint64()))
+	}
+	return keys
+}
+
+func TestSuRF_2(t *testing.T) {
+	rand.Seed(time.Now().UnixNano())
+
+	// Initialize SuRF with an estimated number of keys
+	surf := NewSuRF(1000000)
+
+	// Insert sequential keys
+	seqKeys := generateSequentialKeys(100000)
+	for _, key := range seqKeys {
+		surf.Add(key)
+	}
+
+	// Insert Zipfian distributed keys
+	zipfKeys := generateZipfianKeys(100000)
+	for _, key := range zipfKeys {
+		surf.Add(key)
+	}
+
+	// Perform range queries (Realistic sparse and dense ranges)
+	rangeChecks := []struct {
+		lower, upper []byte
+	}{
+		{[]byte("00005000"), []byte("00010000")}, // Small range (sparse)
+		{[]byte("01000000"), []byte("09000000")}, // Large range (dense)
+		{[]byte("09990000"), []byte("10000000")}, // Edge case boundary
+		{[]byte("50000000"), []byte("60000000")}, // Mid-range values
+		{[]byte("90000000"), []byte("99999999")}, // Upper range
+	}
+
+	for _, check := range rangeChecks {
+		exists := surf.CheckRange(check.lower, check.upper)
+		t.Logf("CheckRange(%s, %s) = %v", check.lower, check.upper, exists)
+	}
+
+	// Delete some random keys and test their absence
+	deleteKeys := [][]byte{
+		[]byte("00005000"),
+		[]byte("01000000"),
+		[]byte("09990000"),
+	}
+
+	for _, key := range deleteKeys {
+		surf.Delete(key)
+		if surf.CheckRange(key, key) {
+			t.Errorf("Failed to delete key %s", key)
+		} else {
+			t.Logf("Successfully deleted key %s", key)
+		}
+	}
+
+	// Introduce false positive tests (ensure we have some)
+	falsePositiveKeys := [][]byte{
+		[]byte("88888888"), // Unlikely inserted
+		[]byte("77777777"),
+		[]byte("66666666"),
+	}
+
+	for _, key := range falsePositiveKeys {
+		exists := surf.CheckRange(key, key)
+		t.Logf("False positive check for key %s = %v", key, exists)
+	}
+}
+
+// Generates keys with specific prefixes
+func generatePrefixedKeys(prefix string, n int) [][]byte {
+	keys := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		keys[i] = []byte(fmt.Sprintf("%s%05d", prefix, i))
+	}
+	return keys
+}
+
+func TestSuRF_3(t *testing.T) {
+	rand.Seed(time.Now().UnixNano())
+
+	// Initialize SuRF with an estimated number of keys
+	surf := NewSuRF(1000000)
+
+	// Define key categories
+	keyPrefixes := []string{"usr", "prod", "txn", "log", "sys"}
+
+	// Insert keys with specific prefixes
+	for _, prefix := range keyPrefixes {
+		prefixedKeys := generatePrefixedKeys(prefix, 100000)
+		for _, key := range prefixedKeys {
+			surf.Add(key)
+		}
+	}
+
+	// Perform range queries for each prefix
+	for _, prefix := range keyPrefixes {
+		lower := []byte(fmt.Sprintf("%s%05d", prefix, 0))
+		upper := []byte(fmt.Sprintf("%s%05d", prefix, 99999))
+		exists := surf.CheckRange(lower, upper)
+		t.Logf("CheckRange(%s, %s) = %v", lower, upper, exists)
+	}
+
+	// Perform additional range queries with mixed prefixes
+	mixedRangeChecks := []struct {
+		lower, upper []byte
+	}{
+		{[]byte("usr00000"), []byte("prod00000")},
+		{[]byte("txn00000"), []byte("log00000")},
+		{[]byte("log00000"), []byte("sys00000")},
+	}
+	for _, check := range mixedRangeChecks {
+		exists := surf.CheckRange(check.lower, check.upper)
+		t.Logf("CheckRange(%s, %s) = %v", check.lower, check.upper, exists)
+	}
+
+	// Delete some keys with specific prefixes and test their absence
+	deleteKeys := [][]byte{
+		[]byte("usr00000"),
+		[]byte("prod00000"),
+		[]byte("txn00000"),
+		[]byte("log00000"),
+		[]byte("sys00000"),
+	}
+
+	for _, key := range deleteKeys {
+		surf.Delete(key)
+		if surf.CheckRange(key, key) {
+			t.Errorf("Failed to delete key %s", key)
+		} else {
+			t.Logf("Successfully deleted key %s", key)
+		}
+	}
+
+	// Test false positives with keys that were not inserted
+	falsePositiveKeys := [][]byte{
+		[]byte("usr99999"),
+		[]byte("prod99999"),
+		[]byte("txn99999"),
+		[]byte("log99999"),
+		[]byte("sys99999"),
+	}
+
+	for _, key := range falsePositiveKeys {
+		exists := surf.CheckRange(key, key)
+		t.Logf("False positive check for key %s = %v", key, exists)
+	}
+
+	// Test edge cases with empty and very large ranges
+	edgeCaseChecks := []struct {
+		lower, upper []byte
+	}{
+		{[]byte(""), []byte("usr00000")},
+		{[]byte("usr00000"), []byte("")},
+		{[]byte(""), []byte("")},
+		{[]byte("usr00000"), []byte("usr99999")},
+		{[]byte("usr00000"), []byte("usr00001")},
+	}
+
+	for _, check := range edgeCaseChecks {
+		exists := surf.CheckRange(check.lower, check.upper)
+		t.Logf("Edge case CheckRange(%s, %s) = %v", check.lower, check.upper, exists)
+	}
+}
+
+func TestSuRF_Contains(t *testing.T) {
+	rand.Seed(time.Now().UnixNano())
+
+	// Initialize SuRF with an estimated number of keys
+	surf := NewSuRF(1000000)
+
+	// Test 1 Basic sequential keys
+	t.Run("Sequential Keys", func(t *testing.T) {
+		seqKeys := generateSequentialKeys(1000)
+		for _, key := range seqKeys {
+			surf.Add(key)
+		}
+
+		// Verify all keys were added
+		for _, key := range seqKeys {
+			if !surf.Contains(key) {
+				t.Errorf("Key %s should exist but Contains returned false", key)
+			}
+		}
+
+		// Test non-existent keys
+		nonExistentKey := []byte("99999999")
+		if surf.Contains(nonExistentKey) {
+			t.Errorf("Key %s should not exist but Contains returned true", nonExistentKey)
+		}
+	})
+
+	// Test 2 Zipfian distributed keys
+	t.Run("Zipfian Keys", func(t *testing.T) {
+		zipfKeys := generateZipfianKeys(1000)
+		for _, key := range zipfKeys {
+			surf.Add(key)
+		}
+
+		// Verify all Zipfian keys were added
+		for _, key := range zipfKeys {
+			if !surf.Contains(key) {
+				t.Errorf("Zipfian key %s should exist but Contains returned false", key)
+			}
+		}
+	})
+
+	// Test 3 Prefixed keys
+	t.Run("Prefixed Keys", func(t *testing.T) {
+		prefixes := []string{"usr", "prod", "txn", "log", "sys"}
+		addedKeys := make([][]byte, 0)
+
+		for _, prefix := range prefixes {
+			prefixedKeys := generatePrefixedKeys(prefix, 100)
+			for _, key := range prefixedKeys {
+				surf.Add(key)
+				addedKeys = append(addedKeys, key)
+			}
+		}
+
+		// Verify all prefixed keys were added
+		for _, key := range addedKeys {
+			if !surf.Contains(key) {
+				t.Errorf("Prefixed key %s should exist but Contains returned false", key)
+			}
+		}
+
+		// Test non-existent prefixed keys
+		nonExistentPrefixedKeys := [][]byte{
+			[]byte("usr99999"),
+			[]byte("prod99999"),
+			[]byte("txn99999"),
+			[]byte("log99999"),
+			[]byte("sys99999"),
+		}
+
+		for _, key := range nonExistentPrefixedKeys {
+			if surf.Contains(key) {
+				t.Errorf("Non-existent key %s should not exist but Contains returned true", key)
+			}
+		}
+	})
+
+	// Test 4 Edge cases
+	t.Run("Edge Cases", func(t *testing.T) {
+		edgeCases := []struct {
+			key    []byte
+			exists bool
+		}{
+			{[]byte(""), false},                   // Empty key
+			{[]byte("a"), false},                  // Single character
+			{[]byte("usr"), false},                // Prefix only
+			{[]byte("usr00000"), true},            // Already added key
+			{[]byte("nonexistent"), false},        // Non-existent key
+			{[]byte("usr000001234567890"), false}, // Very long key
+		}
+
+		for _, tc := range edgeCases {
+			if got := surf.Contains(tc.key); got != tc.exists {
+				t.Errorf("Contains(%s) = %v, want %v", tc.key, got, tc.exists)
+			}
+		}
+	})
+
+	// Test 5 Deletion verification
+	t.Run("Deletion Verification", func(t *testing.T) {
+		key := []byte("deletetest")
+		surf.Add(key)
+
+		if !surf.Contains(key) {
+			t.Errorf("Key %s should exist before deletion", key)
+		}
+
+		surf.Delete(key)
+
+		if surf.Contains(key) {
+			t.Errorf("Key %s should not exist after deletion", key)
+		}
+	})
+
+	// Test 6 Large number of random keys
+	t.Run("Random Keys", func(t *testing.T) {
+		// Add 10000 random keys
+		randomKeys := make([][]byte, 10000)
+		for i := 0; i < 10000; i++ {
+			key := []byte(fmt.Sprintf("%08d", rand.Intn(99999999)))
+			randomKeys[i] = key
+			surf.Add(key)
+		}
+
+		// Verify random sampling of added keys
+		for i := 0; i < 1000; i++ {
+			idx := rand.Intn(len(randomKeys))
+			if !surf.Contains(randomKeys[idx]) {
+				t.Errorf("Random key %s should exist but Contains returned false", randomKeys[idx])
+			}
+		}
+	})
+}


### PR DESCRIPTION
- made is so on deletes bloom filter recreates itself
- added DeleteByRange, DeleteByFilter
- correction on merge logic so keys are only actually removed once sstables at at last level and compacting
- added a SuRF inspired succinct filter package for range member checks.  This has been added to optimize Range and DeleteByRange methods.
- on Delete Bloom or SuRF are adjusted
- test additions

big thanks to @masih with issue #53